### PR TITLE
Emit initial `update` event for tokens with zero balance

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -8,7 +8,7 @@ class Token {
     this.isLoading = !address || !symbol || !balance || !decimals
     this.address = address || '0x0'
     this.symbol  = symbol
-    this.balance = new BN(balance || '0', 16)
+    this.balance = balance ? new BN(balance, 16) : undefined
     this.decimals = decimals ? new BN(decimals) : undefined
     this.owner = owner
 
@@ -33,14 +33,16 @@ class Token {
     return {
       address: this.address,
       symbol: this.symbol,
-      balance: this.balance.toString(10),
+      balance: this.balance ? this.balance.toString(10) : undefined,
       decimals: this.decimals ? parseInt(this.decimals.toString()) : 0,
       string: this.stringify(),
     }
   }
 
   stringify() {
-    return util.stringifyBalance(this.balance, this.decimals || new BN(0))
+    if (this.balance) {
+      return util.stringifyBalance(this.balance, this.decimals || new BN(0))
+    }
   }
 
   async updateSymbol() {


### PR DESCRIPTION
A token constructed without a balance is no longer initialized with a balance of zero. This ensures that an `update` event is emitted if the balance is then updated to be zero.

This is a breaking change, as the initial default balance has changed. It is trivially worked around by initializing the balance to zero though.

Fixes #14