### PR TITLE
Update CircleCI config to v2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+
+workflows:
+  test:
+    jobs:
+      - prep-deps
+      - test:
+          requires:
+            - prep-deps
+
+jobs:
+  prep-deps:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run:
+          name: Install deps
+          command: npm install
+      - persist_to_workspace:
+          root: .
+          paths:
+          - node_modules
+
+  test:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test
+          command: npm test

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 7.7.3


### PR DESCRIPTION
The version of Node.js used has also been updated from v7.7.3 to v10.

The same standard install scripts used in our other repos were not used here because they used `yarn` instead of `npm`. Once we switch to `yarn` in this repo, we can use those install scripts here as well.