### PR TITLE
Include util tests in test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "babel --presets @babel/preset-env --plugins @babel/plugin-transform-runtime -d dist/ lib/",
-    "test": "node test",
+    "test": "tape test/**/*.js",
     "buildSample": "browserify example/index.js -o bundle.js"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,0 @@
-require('./human-standard-token')
-require('./simple-token')
-require('./token-precision')


### PR DESCRIPTION
The `test` command now runs all files in the `test` directory rather than just those imported by the `index` file. Previously the tests in `test/unit.js` weren't being run.