### PR TITLE
Create integration test directory

### DIFF
--- a/test/integration/human-standard-token.js
+++ b/test/integration/human-standard-token.js
@@ -1,10 +1,12 @@
+const fs = require('fs')
+const path = require('path')
 const test = require('tape')
 const TestRPC = require('ethereumjs-testrpc')
 const provider = TestRPC.provider()
 const ProviderEngine = require('web3-provider-engine')
-const fs = require('fs')
+
 const solc = require('solc')
-const TokenTracker = require('../lib')
+const TokenTracker = require('../../lib')
 const BN = require('ethjs').BN
 
 const Eth = require('ethjs-query')
@@ -12,7 +14,7 @@ const EthContract = require('ethjs-contract')
 const eth = new Eth(provider)
 const contract = new EthContract(eth)
 
-const source = fs.readFileSync(__dirname + '/contracts/Token.sol').toString();
+const source = fs.readFileSync(path.resolve(__dirname, '..', 'contracts/Token.sol')).toString();
 const compiled = solc.compile(source, 1)
 const HumanStandardDeployer = compiled.contracts[':HumanStandardToken']
 

--- a/test/integration/simple-token.js
+++ b/test/integration/simple-token.js
@@ -1,10 +1,11 @@
+const fs = require('fs')
+const path = require('path')
 const test = require('tape')
 const TestRPC = require('ethereumjs-testrpc')
 const provider = TestRPC.provider()
 const ProviderEngine = require('web3-provider-engine')
-const fs = require('fs')
 const solc = require('solc')
-const TokenTracker = require('../lib')
+const TokenTracker = require('../../lib')
 const BN = require('ethjs').BN
 
 const Eth = require('ethjs-query')
@@ -12,7 +13,7 @@ const EthContract = require('ethjs-contract')
 const eth = new Eth(provider)
 const contract = new EthContract(eth)
 
-const source = fs.readFileSync(__dirname + '/contracts/Token.sol').toString();
+const source = fs.readFileSync(path.resolve(__dirname, '..', 'contracts/Token.sol')).toString();
 const compiled = solc.compile(source, 1)
 const SimpleTokenDeployer = compiled.contracts[':SimpleToken']
 

--- a/test/integration/token-precision.js
+++ b/test/integration/token-precision.js
@@ -1,12 +1,13 @@
+const fs = require('fs')
+const path = require('path')
 const test = require('tape')
 const TestRPC = require('ethereumjs-testrpc')
 const provider = TestRPC.provider()
 const ProviderEngine = require('web3-provider-engine')
-const fs = require('fs')
 const solc = require('solc')
-const TokenTracker = require('../lib')
+const TokenTracker = require('../../lib')
 const BN = require('ethjs').BN
-const util = require('../lib/util')
+const util = require('../../lib/util')
 
 const Eth = require('ethjs-query')
 const EthContract = require('ethjs-contract')
@@ -14,7 +15,7 @@ const eth = new Eth(provider)
 const contract = new EthContract(eth)
 let count = 0
 
-const source = fs.readFileSync(__dirname + '/contracts/ZeppelinToken.sol').toString();
+const source = fs.readFileSync(path.resolve(__dirname, '..', 'contracts/ZeppelinToken.sol')).toString();
 const compiled = solc.compile(source, 1)
 
 const SimpleTokenDeployer = compiled.contracts[':TutorialToken']


### PR DESCRIPTION
The remainder of the test modules that aren't unit tests have been moved into this new `integration` directory. I figured that it would be accurate to describe these as integration tests since they test the
token tracker as a whole, and focus more on specific common use-cases rather than on covering the API of the tracker itself.

The main motivation behind this is that I want to create a module for test utility functions, and it would be nice if this was kept separate from the tests themselves.