### PR TITLE
Create token unit tests

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,47 @@
+const assert = require('assert').strict
+const fs = require('fs')
+const path = require('path')
+const TestRPC = require('ethereumjs-testrpc')
+const Eth = require('ethjs-query')
+const EthContract = require('ethjs-contract')
+const solc = require('solc')
+
+const source = fs.readFileSync(path.resolve(__dirname, 'contracts/Token.sol')).toString();
+const compiled = solc.compile(source, 1)
+const SimpleTokenDeployer = compiled.contracts[':SimpleToken']
+
+const defaultQuantity = '100000000000000000000' // 100 x 10 ^ 18
+async function setupSimpleTokenEnvironment ({ qty = defaultQuantity } = {}) {
+  const provider = TestRPC.provider()
+  const eth = new Eth(provider)
+
+  const addresses = await eth.accounts()
+  assert(addresses.length > 0, 'test network should be initialized with accounts')
+
+  const owner = addresses[0]
+  const contract = new EthContract(eth)
+  const abi = JSON.parse(SimpleTokenDeployer.interface)
+  const StandardToken = contract(abi, SimpleTokenDeployer.bytecode, {
+    from: owner,
+    gas: '3000000',
+    gasPrice: '30000',
+  })
+
+  const txHash = await StandardToken.new(qty)
+  assert.ok(txHash, 'should have published the token and returned a transaction hash')
+
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  const receipt = await eth.getTransactionReceipt(txHash)
+
+  const tokenAddress = receipt.contractAddress
+  assert.ok(tokenAddress, 'should have a token address')
+
+  const token = StandardToken.at(tokenAddress)
+  const result = await token.balanceOf(owner)
+  const balance = result[0]
+  assert.equal(balance.toString(10), qty, 'owner should have all')
+
+  return { addresses, eth, provider, token, tokenAddress }
+}
+
+module.exports = { setupSimpleTokenEnvironment }

--- a/test/integration/simple-token.js
+++ b/test/integration/simple-token.js
@@ -1,56 +1,14 @@
-const fs = require('fs')
-const path = require('path')
-const assert = require('assert').strict
 const test = require('tape')
-const TestRPC = require('ethereumjs-testrpc')
 const ProviderEngine = require('web3-provider-engine')
-const solc = require('solc')
-const TokenTracker = require('../../lib')
+
 const BN = require('ethjs').BN
 
-const Eth = require('ethjs-query')
-const EthContract = require('ethjs-contract')
-
-const source = fs.readFileSync(path.resolve(__dirname, '..', 'contracts/Token.sol')).toString();
-const compiled = solc.compile(source, 1)
-const SimpleTokenDeployer = compiled.contracts[':SimpleToken']
+const TokenTracker = require('../../lib')
+const { setupSimpleTokenEnvironment } = require('../helper')
 
 let tracked
 const qty = '100000000000000000000' // 100 x 10 ^ 18
 const less = '10000000000000000000' // 100 x 10 ^ 17
-
-async function setupSimpleTokenEnvironment () {
-  const provider = TestRPC.provider()
-  const eth = new Eth(provider)
-
-  const addresses = await eth.accounts()
-  assert(addresses.length > 0, 'test network should be initialized with accounts')
-
-  const owner = addresses[0]
-  const contract = new EthContract(eth)
-  const abi = JSON.parse(SimpleTokenDeployer.interface)
-  const StandardToken = contract(abi, SimpleTokenDeployer.bytecode, {
-    from: owner,
-    gas: '3000000',
-    gasPrice: '30000',
-  })
-
-  const txHash = await StandardToken.new(qty)
-  assert.ok(txHash, 'should have published the token and returned a transaction hash')
-
-  await new Promise((resolve) => setTimeout(resolve, 300))
-  const receipt = await eth.getTransactionReceipt(txHash)
-
-  const tokenAddress = receipt.contractAddress
-  assert.ok(tokenAddress, 'should have a token address')
-
-  const token = StandardToken.at(tokenAddress)
-  const result = await token.balanceOf(owner)
-  const balance = result[0]
-  assert.equal(balance.toString(10), qty, 'owner should have all')
-
-  return { addresses, eth, provider, token, tokenAddress }
-}
 
 test('StandardToken balances are tracked', function (t) {
   let addresses

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -1,0 +1,223 @@
+const test = require('tape')
+const BN = require('ethjs').BN
+
+const Token = require('../../lib/token')
+const { setupSimpleTokenEnvironment } = require('../helper')
+
+test('token with minimal options', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    contract,
+    owner: addresses[0],
+  })
+
+  t.deepEqual(
+    token.serialize(),
+    {
+      address: '0x0',
+      symbol: undefined,
+      balance: '0',
+      decimals: 0,
+      string: '0'
+    },
+    'should serialize minimal token correctly',
+  )
+  t.end()
+})
+
+test('token with address', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract, tokenAddress } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    address: tokenAddress,
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.address, tokenAddress, 'should serialize token address correctly')
+  t.end()
+})
+
+test('token with symbol', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    contract,
+    owner: addresses[0],
+    symbol: 'TEST',
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.symbol, 'TEST', 'should serialize token symbol correctly')
+  t.end()
+})
+
+test('token with number balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: 10,
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '10', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with unprefixed hex string balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: '10',
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '16', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with BN.js balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: new BN(10),
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '10', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with array balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: [10],
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '10', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with zero balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: 0,
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '0', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with empty string balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    balance: '',
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '0', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: 10,
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with string decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: '10',
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with zero decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: 0,
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 0, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with empty string decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: '',
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 0, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with BN.js decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: new BN(10),
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with array decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
+    decimals: [10],
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})


### PR DESCRIPTION
The `createSimpleTokenEnvironment` function was extracted from the `simple-token` tests into a helper library, and reused for the token unit tests.

The token unit tests focused on the constructor specifically, using the `serialize` function to assert expectations about the token state. The rest of the module has not yet been tested, and neither have conditions that are known to make the token fail upon construction. The failure conditions will be tested in a later PR; at the moment it's difficult to test them because they throw an exception asynchronously, after the constructor returns.