### PR TITLE
Validate token parameters

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -1,8 +1,17 @@
 const BN = require('ethjs').BN
 const util = require('./util')
 
-// bn.js requires extra validation to safely use
-// See here: https://github.com/indutny/bn.js/issues/151
+/**
+ * Checks whether the given input and base will produce an invalid bn instance.
+ *
+ * bn.js requires extra validation to safely use, so this function allows
+ * us to typecheck the params we pass to it.
+ *
+ * @see {@link https://github.com/indutny/bn.js/issues/151}
+ * @param {any} input - the bn.js input
+ * @param {number} base - the bn.js base argument
+ * @returns {boolean}
+ */
 function _isInvalidBnInput (input, base) {
   return (
     typeof input === 'string' &&

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,14 +1,41 @@
 const BN = require('ethjs').BN
 const util = require('./util')
 
+// bn.js requires extra validation to safely use
+// See here: https://github.com/indutny/bn.js/issues/151
+function _isInvalidBnInput (input) {
+  return (
+    typeof input === 'string' &&
+    (
+      input.startsWith('0x') ||
+      Number.isNaN(parseInt(input))
+    )
+  )
+}
+
 class Token {
 
-  constructor (opts = {}) {
-    const { address, symbol, balance, decimals, contract, owner } = opts
+  constructor ({ address, symbol, balance, decimals, contract, owner } = {}) {
+    if (!contract) {
+      throw new Error('Missing requried \'contract\' parameter')
+    } else if (!owner) {
+      throw new Error('Missing requried \'owner\' parameter')
+    }
     this.isLoading = !address || !symbol || !balance || !decimals
     this.address = address || '0x0'
     this.symbol  = symbol
-    this.balance = new BN(balance || '0', 16)
+
+    if (!balance) {
+      balance = '0'
+    } else if (_isInvalidBnInput(balance)) {
+      throw new Error('Invalid \'balance\' option provided; must be non-prefixed hex string if given as string')
+    }
+
+    if (decimals && _isInvalidBnInput(decimals)) {
+      throw new Error('Invalid \'decimals\' option provided; must be non-prefixed hex string if given as string')
+    }
+
+    this.balance = new BN(balance, 16)
     this.decimals = decimals ? new BN(decimals) : undefined
     this.owner = owner
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -3,12 +3,12 @@ const util = require('./util')
 
 // bn.js requires extra validation to safely use
 // See here: https://github.com/indutny/bn.js/issues/151
-function _isInvalidBnInput (input) {
+function _isInvalidBnInput (input, base) {
   return (
     typeof input === 'string' &&
     (
       input.startsWith('0x') ||
-      Number.isNaN(parseInt(input))
+      Number.isNaN(parseInt(input, base))
     )
   )
 }
@@ -27,11 +27,11 @@ class Token {
 
     if (!balance) {
       balance = '0'
-    } else if (_isInvalidBnInput(balance)) {
+    } else if (_isInvalidBnInput(balance, 16)) {
       throw new Error('Invalid \'balance\' option provided; must be non-prefixed hex string if given as string')
     }
 
-    if (decimals && _isInvalidBnInput(decimals)) {
+    if (decimals && _isInvalidBnInput(decimals, 10)) {
       throw new Error('Invalid \'decimals\' option provided; must be non-prefixed hex string if given as string')
     }
 

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -4,6 +4,31 @@ const BN = require('ethjs').BN
 const Token = require('../../lib/token')
 const { setupSimpleTokenEnvironment } = require('../helper')
 
+
+test('token with no parameters', function (t) {
+  t.throws(() => (new Token()), 'should throw if missing contract parameter')
+  t.end()
+})
+
+test('token with empty options', function (t) {
+  t.throws(() => (new Token({})), 'should throw if missing contract parameter')
+  t.end()
+})
+
+test('token with just contract option', async function (t) {
+  t.plan(1)
+  const { token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(() => (new Token({ contract })), 'should throw if missing owner parameter')
+  t.end()
+})
+
+test('token with just owner option', async function (t) {
+  t.plan(1)
+  const { addresses } = await setupSimpleTokenEnvironment()
+  t.throws(() => (new Token({ owner: addresses[0] })), 'should throw if missing contract parameter')
+  t.end()
+})
+
 test('token with minimal options', async function (t) {
   t.plan(1)
   const { addresses, token: contract } = await setupSimpleTokenEnvironment()
@@ -110,6 +135,38 @@ test('token with array balance', async function (t) {
   t.end()
 })
 
+test('token with prefixed hex string balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(
+    () => {
+      new Token({
+        balance: '0x10',
+        contract,
+        owner: addresses[0],
+      })
+    },
+    'should throw if given prefixed hex string balance',
+  )
+  t.end()
+})
+
+test('token with invalid string balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(
+    () => {
+      new Token({
+        balance: 'z',
+        contract,
+        owner: addresses[0],
+      })
+    },
+    'should throw if given invalid string balance',
+  )
+  t.end()
+})
+
 test('token with zero balance', async function (t) {
   t.plan(1)
   const { addresses, token: contract } = await setupSimpleTokenEnvironment()
@@ -163,6 +220,38 @@ test('token with string decimals', async function (t) {
 
   const serializedToken = token.serialize()
   t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with prefixed hex string decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(
+    () => {
+      new Token({
+        decimals: '0x10',
+        contract,
+        owner: addresses[0],
+      })
+    },
+    'should throw if given prefixed hex string decimals',
+  )
+  t.end()
+})
+
+test('token with invalid string decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(
+    () => {
+      new Token({
+        decimals: 'z',
+        contract,
+        owner: addresses[0],
+      })
+    },
+    'should throw if given invalid string decimals',
+  )
   t.end()
 })
 

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -97,6 +97,20 @@ test('token with unprefixed hex string balance', async function (t) {
   t.plan(1)
   const { addresses, token: contract } = await setupSimpleTokenEnvironment()
   const token = new Token({
+    balance: 'f',
+    contract,
+    owner: addresses[0],
+  })
+
+  const serializedToken = token.serialize()
+  t.deepEqual(serializedToken.balance, '15', 'should serialize token balance correctly')
+  t.end()
+})
+
+test('token with decimal string balance', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  const token = new Token({
     balance: '10',
     contract,
     owner: addresses[0],
@@ -220,6 +234,22 @@ test('token with string decimals', async function (t) {
 
   const serializedToken = token.serialize()
   t.deepEqual(serializedToken.decimals, 10, 'should serialize token decimals correctly')
+  t.end()
+})
+
+test('token with unprefixed hex string decimals', async function (t) {
+  t.plan(1)
+  const { addresses, token: contract } = await setupSimpleTokenEnvironment()
+  t.throws(
+    () => {
+      new Token({
+        decimals: 'f',
+        contract,
+        owner: addresses[0],
+      })
+    },
+    'should throw if given unprefixed hex string decimals',
+  )
   t.end()
 })
 


### PR DESCRIPTION
The token constructor parameters are now validated so that they fail synchronously when they would have previously led to an asynchronously thrown error (that was then caught and logged), or an invalid result. Tests have been added for these cases as well.