### PR TITLE
Prevent redundant update caused by simultaneous token updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,9 @@ class TokenTracker extends SafeEventEmitter {
       return this.createTokenFrom(tokenOpts)
     })
 
+    // initialize state
+    this._oldBalances = this.serialize()
+
     this.updateBalances = this.updateBalances.bind(this)
 
     this.running = true
@@ -40,19 +43,13 @@ class TokenTracker extends SafeEventEmitter {
   }
 
   async updateBalances() {
-    const oldBalances = this.serialize()
-
     try {
       await Promise.all(this.tokens.map((token) => {
         return token.updateBalance()
       }))
 
       const newBalances = this.serialize()
-      if (!deepEqual(newBalances, oldBalances)) {
-        if (this.running) {
-          this.emit('update', newBalances)
-        }
-      }
+      this._update(newBalances)
     } catch (reason) {
       this.emit('error', reason)
     }
@@ -73,6 +70,14 @@ class TokenTracker extends SafeEventEmitter {
   stop(){
     this.running = false
     this.blockTracker.removeListener('latest', this.updateBalances)
+  }
+
+  _update(newBalances) {
+    if (!this.running || deepEqual(newBalances, this._oldBalances)) {
+      return
+    }
+    this._oldBalances = newBalances
+    this.emit('update', newBalances)
   }
 }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -104,6 +104,61 @@ test('tracker with minimal token and one block update with no changes', async fu
   }
 })
 
+test('tracker with minimal token and two rapid block updates, the first with changes', async function (t) {
+  t.plan(2)
+  let tracker
+  try {
+    const { addresses, provider, token, tokenAddress } = await setupSimpleTokenEnvironment()
+    tracker = new TokenTracker({
+      pollingInterval: 20,
+      provider,
+      tokens: [
+        {
+          address: tokenAddress,
+        }
+      ],
+      userAddress: addresses[1],
+    })
+
+    const updates = []
+    tracker.on('update', (tokens) => {
+      updates.push(tokens)
+    })
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    await Promise.all([
+      token.transfer(addresses[1], '110'),
+      token.transfer(addresses[1], '0'),
+    ])
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    t.equal(updates.length, 2, 'should have only two updates')
+    t.deepEqual(
+      updates,
+      [
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '0',
+          decimals: 0,
+          string: '0',
+        }],
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '110',
+          decimals: 0,
+          string: '110',
+        }],
+      ],
+      'should have expected state for both updates'
+    )
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})
+
 test('tracker with minimal token and one block update with changes', async function (t) {
   t.plan(1)
   let tracker


### PR DESCRIPTION
The tracker attempts to compare the previous token balances to the current token balance when deciding whether to emit an `update` event. However, the previous balance it compares against is the balance before the update, not last balance emitted. If a second token update is started before the first one finishes, both will be comparing using the same previous value, so both might result in the same `update` event being emitted.

This redundant `update` event can occur when some token balance has changed, and two token updates are triggered in quick succession. This could happen if two blocks were mined in quick succession, or if two updates were manually triggered, or if a block was mined and an update triggered at around the same time.

This has been prevented by caching the token state emitted by the most recent `update` event. This cached state is used to determine whether the token state has changed, rather than the state before the update began.

The state is initialized prior to the first update to remain consistent with the previous behavior. This will be removed in a subsequent PR.