### PR TITLE
Ensure first token update is always emitted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,6 @@ class TokenTracker extends SafeEventEmitter {
       return this.createTokenFrom(tokenOpts)
     })
 
-    // initialize state
-    this._oldBalances = this.serialize()
-
     this.updateBalances = this.updateBalances.bind(this)
 
     this.running = true

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -59,6 +59,51 @@ test('tracker with minimal token', async function (t) {
   }
 })
 
+test('tracker with token including metadata', async function (t) {
+  t.plan(2)
+  let tracker
+  try {
+    const { addresses, provider, tokenAddress } = await setupSimpleTokenEnvironment()
+    tracker = new TokenTracker({
+      pollingInterval: 20,
+      provider,
+      tokens: [
+        {
+          address: tokenAddress,
+          symbol: 'TKN',
+          decimals: 0,
+        }
+      ],
+      userAddress: addresses[1],
+    })
+
+    const updates = []
+    tracker.on('update', (tokens) => {
+      updates.push(tokens)
+    })
+
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    t.equal(updates.length, 1, 'should have one update')
+    t.deepEqual(
+      updates,
+      [
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '0',
+          decimals: 0,
+          string: '0',
+        }],
+      ],
+      'should have expected initial state'
+    )
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})
+
 test('tracker with minimal token and one block update with no changes', async function (t) {
   t.plan(2)
   let tracker


### PR DESCRIPTION
The first token update was sometimes not emitted because the initial token state happened to be the same as the state after the update. This was particularly problematic with the balance, as the tracker will initialize each token with a balance of zero even if none was specified.

The initial token state has been removed, which ensures the first update will always be emitted.

I considered skipping the initial update event if all of the token data was fully specified from the beginning (including the balance), but decided it wasn't worthwhile. The token data includes a derived field anyway (the `string` field) which can't be specified, so technically it has always changed at least with that field. If we were interested in doing this in the future but preserving the token defaults (balance and decimals set to zero), we'd have to add a separate serialization method to the token module that doesn't apply those defaults.

Fixes #14 