### PR TITLE
Emit events for initial token updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,14 @@ class TokenTracker extends SafeEventEmitter {
       return this.createTokenFrom(tokenOpts)
     })
 
+    Promise.all(this.tokens.map((token) => token.update()))
+      .then((newBalances) => {
+        this._update(newBalances)
+      })
+      .catch((error) => {
+        this.emit('error', error)
+      })
+
     this.updateBalances = this.updateBalances.bind(this)
 
     this.running = true
@@ -62,6 +70,13 @@ class TokenTracker extends SafeEventEmitter {
   add(opts) {
     const token = this.createTokenFrom(opts)
     this.tokens.push(token)
+    token.update()
+      .then(() => {
+        this._update(this.serialize())
+      })
+      .catch((error) => {
+        this.emit('error', error)
+      })
   }
 
   stop(){

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,10 @@ class TokenTracker extends SafeEventEmitter {
       return this.createTokenFrom(tokenOpts)
     })
 
+    // initialize to empty array to ensure a tracker initialized
+    // with zero tokens doesn't emit an update until a token is added.
+    this._oldBalances = []
+
     Promise.all(this.tokens.map((token) => token.update()))
       .then((newBalances) => {
         this._update(newBalances)

--- a/lib/token.js
+++ b/lib/token.js
@@ -47,22 +47,17 @@ class Token {
     this.balance = new BN(balance, 16)
     this.decimals = decimals ? new BN(decimals) : undefined
     this.owner = owner
-
     this.contract = contract
-    this.update()
-    .catch((reason) => {
-      console.error('token updating failed', reason)
-    })
   }
 
   async update() {
-    const results = await Promise.all([
+    await Promise.all([
       this.symbol || this.updateSymbol(),
       this.updateBalance(),
       this.decimals || this.updateDecimals(),
     ])
     this.isLoading = false
-    return results
+    return this.serialize()
   }
 
   serialize() {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -303,6 +303,54 @@ test('tracker with minimal token and one block update with changes', async funct
   }
 })
 
+test('tracker with minimal token and one immediate block update with changes', async function (t) {
+  t.plan(1)
+  let tracker
+  try {
+    const { addresses, provider, token, tokenAddress } = await setupSimpleTokenEnvironment()
+    tracker = new TokenTracker({
+      pollingInterval: 20,
+      provider,
+      tokens: [
+        {
+          address: tokenAddress,
+        }
+      ],
+      userAddress: addresses[1],
+    })
+
+    const updates = []
+    tracker.on('update', (tokens) => {
+      updates.push(tokens)
+    })
+    await token.transfer(addresses[1], '110')
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    t.deepEqual(
+      updates,
+      [
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '0',
+          decimals: 0,
+          string: '0',
+        }],
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '110',
+          decimals: 0,
+          string: '110',
+        }],
+      ],
+      'should have expected state for both updates'
+    )
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})
 
 test('tracker with broken provider', async function (t) {
   t.plan(1)

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -367,7 +367,7 @@ test('tracker with broken provider', async function (t) {
       }],
     })
     tracker.on('error', () => {
-      t.pass('should emit error event upon')
+      t.pass('should emit error event')
     })
     await new Promise((resolve) => setTimeout(() => resolve(), 200))
     t.end()

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -253,3 +253,28 @@ test('tracker with minimal token and one block update with changes', async funct
     tracker.stop()
   }
 })
+
+
+test('tracker with broken provider', async function (t) {
+  t.plan(1)
+  let tracker
+  try {
+    tracker = new TokenTracker({
+      provider: {
+        sendAsync: () => {
+          throw new Error('Fake provider error')
+        }
+      },
+      tokens: [{
+        address: '0xf83c3761a5c0042ab9a694d29520aa9cd6788987',
+      }],
+    })
+    tracker.on('error', () => {
+      t.pass('should emit error event upon')
+    })
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -4,11 +4,20 @@ const TokenTracker = require('../../lib/')
 const { setupSimpleTokenEnvironment } = require('../helper')
 
 test('tracker with minimal options', async function (t) {
-  t.plan(1)
+  t.plan(2)
   let tracker
   try {
     const { provider } = await setupSimpleTokenEnvironment()
     tracker = new TokenTracker({ provider })
+
+    const updates = []
+    tracker.on('update', (tokens) => {
+      updates.push(tokens)
+    })
+
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    t.equal(updates.length, 0, 'should have zero updates')
     t.deepEqual(tracker.serialize(), [], 'should serialize as an empty array')
     t.end()
   } finally {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -25,6 +25,46 @@ test('tracker with minimal options', async function (t) {
   }
 })
 
+test('tracker with token added after initialization', async function (t) {
+  t.plan(2)
+  let tracker
+  try {
+    const { addresses, provider, tokenAddress } = await setupSimpleTokenEnvironment()
+    tracker = new TokenTracker({
+      pollingInterval: 20,
+      provider,
+      userAddress: addresses[1],
+    })
+
+    const updates = []
+    tracker.on('update', (tokens) => {
+      updates.push(tokens)
+    })
+
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+    tracker.add({ address: tokenAddress })
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+
+    t.equal(updates.length, 1, 'should have one update')
+    t.deepEqual(
+      updates,
+      [
+        [{
+          address: tokenAddress,
+          symbol: 'TKN',
+          balance: '0',
+          decimals: 0,
+          string: '0',
+        }],
+      ],
+      'should have expected initial state'
+    )
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})
+
 test('tracker with minimal token', async function (t) {
   t.plan(2)
   let tracker


### PR DESCRIPTION
Previously the Token constructor had triggered an asynchronous update of the token metadata and balance. Unfortunately this update wouldn't trigger either an `update` after completion or an `error` event after failure, leaving the user of the tracker unable to handle the error and unable to tell when the metadata update had finished.

This update has been moved into the Token Tracker instead, and now emits both `update` and `error` events as appropriate.

The Token `serialize` method return value has changed to return the serialized token rather than an array of symbol, balance, and decimal. This was done because it was slightly more convenient, and the old return value was never used anywhere anyway.