### PR TITLE
Move package under @metamask scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A JS module for tracking Ethereum tokens and their values over time.
 
 ## Installation
 
-`npm install eth-token-tracker -S`
+`npm install '@metamask/eth-token-tracker'`
 
 ## Usage
 
 ```javascript
-const TokenTracker = require('eth-token-tracker')
+const TokenTracker = require('@metamask/eth-token-tracker')
 
 var tokenTracker = new TokenTracker({
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eth-token-tracker",
+  "name": "@metamask/eth-token-tracker",
   "version": "1.1.11",
   "description": "A module for tracking Ethereum token balances over block changes.",
   "main": "dist/index.js",
@@ -13,6 +13,10 @@
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/MetaMask/eth-token-tracker.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
We're in the process of moving all of our packages under the same `@metamask` scope, to make them easier to manage.

The README has been updated to use the new scoped package name. The install command shown has also been updated to remove the `-S` flag, which has been removed by npm (it now saves by default).