### PR TITLE
Slice all non significant zeroes in stringifyBalance

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -27,8 +27,14 @@ module.exports = {
       decimalIndex = 1
     }
 
-    const result = `${bal.substr(0, len - decimals)}.${bal.substr(decimalIndex, 3)}`
-    return result
+    const whole = bal.substr(0, len - decimals)
+    const fractional = bal.substr(decimalIndex, 3)
+    if (/0+$/.test(fractional)) {
+      let withOnlySigZeroes = bal.substr(decimalIndex).replace(/0+$/, '')
+      if (withOnlySigZeroes.length > 0) withOnlySigZeroes = `.${withOnlySigZeroes}`
+      return `${whole}${withOnlySigZeroes}`
+    }
+    return `${whole}.${fractional}`
   }
 
 }

--- a/test/integration/human-standard-token.js
+++ b/test/integration/human-standard-token.js
@@ -105,7 +105,7 @@ test('HumanStandardToken balances are tracked', function (t) {
     t.equal(tracked.decimals.toString(), '2', 'decimals received')
 
     const data = tracked.serialize()
-    t.equal(data.string, '8.90', 'represents decimals')
+    t.equal(data.string, '8.9', 'represents decimals')
 
     const serialized = tokenTracker.serialize()
     t.equal(serialized[0].string, data.string, 'serializes data')
@@ -141,11 +141,11 @@ test('HumanStandardToken balance changes are emitted', function (t) {
 
     updateCounter++
     if (updateCounter < 2) {
-      return t.equal(tracked.string, '8.90', 'initial balance loaded from last test')
+      return t.equal(tracked.string, '8.9', 'initial balance loaded from last test')
     }
 
     t.equal(tracked.symbol, SET_SYMBOL, 'symbol retrieved')
-    t.equal(tracked.string, '7.90', 'balance updated')
+    t.equal(tracked.string, '7.9', 'balance updated')
     tokenTracker.stop()
     t.end()
   })
@@ -181,7 +181,7 @@ test('HumanStandardToken non balance changes are not emitted', function (t) {
 
     updateCounter++
     if (updateCounter < 2) {
-      return t.equal(tracked.string, '7.90', 'initial balance loaded from last test')
+      return t.equal(tracked.string, '7.9', 'initial balance loaded from last test')
     }
 
     t.notOk(true, 'a second event should not have fired')

--- a/test/integration/simple-token.js
+++ b/test/integration/simple-token.js
@@ -63,7 +63,7 @@ test('StandardToken balances are tracked', function (t) {
     t.equal(tracked.address, tokenAddress, 'token address set')
     t.equal(tracked.balance.toString(10), should, 'tokens sent')
 
-    t.ok(tracked.string.indexOf('90.0') === 0, 'represents decimals')
+    t.ok(tracked.string.indexOf('90') === 0, 'represents decimals')
 
     tokenTracker.stop()
     t.end()

--- a/test/integration/token-precision.js
+++ b/test/integration/token-precision.js
@@ -37,7 +37,7 @@ generateTestWithParams({
   precision: 2,
   result: function (token, t) {
     t.equal(tracked.decimals, 2, 'initial decimals retained')
-    t.equal(tracked.string, '100.00', 'represents decimals')
+    t.equal(tracked.string, '100', 'represents decimals')
     t.end()
   },
 })
@@ -57,7 +57,7 @@ generateTestWithParams({
   precision: 18,
   result: function (token, t) {
     t.equal(tracked.decimals, 18, 'initial decimals retained')
-    t.equal(tracked.string, '0.000', 'represents decimals')
+    t.equal(tracked.string, '0.00000000000000012', 'represents decimals')
     t.end()
   },
 })
@@ -68,7 +68,7 @@ generateTestWithParams({
   precision: 18,
   result: function (token, t) {
     t.equal(tracked.decimals, 18, 'initial decimals retained')
-    t.equal(tracked.string, '0.000', 'represents decimals')
+    t.equal(tracked.string, '0.000002179663820576', 'represents decimals')
     t.end()
   },
 })
@@ -79,7 +79,7 @@ generateTestWithParams({
   precision: 18,
   result: function (token, t) {
     t.equal(tracked.decimals, 18, 'initial decimals retained')
-    t.equal(tracked.string, '0.000', 'represents decimals')
+    t.equal(tracked.string, '0.00000000000027929', 'represents decimals')
     t.end()
   },
 })
@@ -88,7 +88,7 @@ test('Precision rendering test for issue 2162', function (t) {
   const quantity = new BN('279290')
   const precision = new BN('18')
   const string = util.stringifyBalance(quantity, precision)
-  t.equal(string, '0.000', 'represents decimals')
+  t.equal(string, '0.00000000000027929', 'represents decimals')
   t.end()
 })
 


### PR DESCRIPTION
In the MetaMask Extension, having a balance of tokens that would result in a decimal format including significant numbers past the hundredths place would result in a zero balance being displayed for both the token and for fiat currency. Instead of arbitrarily returning 3 decimals of significance, this update uses a regex to trim all zeroes between the decimal point and the end of the string that are uninterrupted by any other value. It will start at the first 0 in a series of zeroes and cut until the end of the string.

'0.000000010000' -> '0.00000001'
'0.000000000000' -> '0'
'0.010000000000' -> '0.01'
'15.00000000000' -> '15'

etc

If the result of substring'ing the fractional part of the number is not a sequence of zeroes, the original logic is preserved:
'15.001981241243' -> '15.001'
'0.0187777777777' -> '0.018'

<details>
<summary>Before</summary>

<img src="https://user-images.githubusercontent.com/4448075/88091589-e2bdc380-cb54-11ea-8873-33b0b8b6b9ce.png"/>

</details>

<details>
<summary>After</summary>

<img width="360" alt="Screen Shot 2020-07-21 at 1 14 54 PM" src="https://user-images.githubusercontent.com/4448075/88091623-f0734900-cb54-11ea-997a-5e503fdb65bf.png">

</details>

