### PR TITLE
Ensure that a 0 appears at the start of a balance which is >= 0.1 and < 1

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -18,7 +18,7 @@ module.exports = {
     let decimalIndex = len - decimals
     let prefix = ''
 
-    if (decimalIndex < 0) {
+    if (decimalIndex <= 0) {
       while (prefix.length <= decimalIndex * -1) {
         prefix += '0'
         len++

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -42,3 +42,13 @@ test('token balance stringify 4', function (t) {
   t.equal(result, '0.012', 'Creates correct balance.')
   t.end()
 })
+
+test('token balance stringify 5', function (t) {
+  const balance = new BN('1200', 10)
+  const decimals = new BN(4)
+
+  const result = util.stringifyBalance(balance, decimals)
+
+  t.equal(result, '0.12', 'Creates correct balance.')
+  t.end()
+})


### PR DESCRIPTION
This PR fixes a bug in that affects the `string` value on token objects that are emitted from the eth-token-tracker.

For any token whose string value is < 0.1, the string correctly has a `'0'` prefix before the decimal point. However, for values that are >= 0.1 and < 1, the string does not have a 0 prefix.

The end result for the user of metamask-extension is that if they have 0.2 ABC tokens, that will be rendered as ".2 ABC", but if they have 0.02 ABC tokens, it would be rendered as "0.02 ABC".

This PR fixes this and makes both consistently prefixed with 0.

This PR adds a unit test that would have caught this. The unit test fails before the change in this PR and passes after the change.