### PR TITLE
allow updating failed tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add ability to include tokens with balance errors in update events, behind an option flag (#53)
 
 ## [3.0.1] - 2020-09-11
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ class TokenTracker extends SafeEventEmitter {
   constructor (opts = {}) {
     super()
 
+    this.includeFailedTokens = opts.includeFailedTokens || false
     this.userAddress = opts.userAddress || '0x0'
     this.provider = opts.provider
     const pollingInterval = opts.pollingInterval || 4000
@@ -68,7 +69,15 @@ class TokenTracker extends SafeEventEmitter {
     const owner = this.userAddress
     const { address, symbol, balance, decimals } = opts
     const contract = this.TokenContract.at(address)
-    return new Token({ address, symbol, balance, decimals, contract, owner })
+    return new Token({
+      address,
+      symbol,
+      balance,
+      decimals,
+      contract,
+      owner,
+      throwOnBalanceError: this.includeFailedTokens === false,
+    })
   }
 
   add(opts) {

--- a/lib/token.js
+++ b/lib/token.js
@@ -24,7 +24,15 @@ function _isInvalidBnInput (input, base) {
 
 class Token {
 
-  constructor ({ address, symbol, balance, decimals, contract, owner } = {}) {
+  constructor ({
+    address,
+    symbol,
+    balance,
+    decimals,
+    contract,
+    owner,
+    throwOnBalanceError
+  } = {}) {
     if (!contract) {
       throw new Error('Missing requried \'contract\' parameter')
     } else if (!owner) {
@@ -33,6 +41,7 @@ class Token {
     this.isLoading = !address || !symbol || !balance || !decimals
     this.address = address || '0x0'
     this.symbol  = symbol
+    this.throwOnBalanceError = throwOnBalanceError
 
     if (!balance) {
       balance = '0'
@@ -67,6 +76,7 @@ class Token {
       balance: this.balance.toString(10),
       decimals: this.decimals ? parseInt(this.decimals.toString()) : 0,
       string: this.stringify(),
+      balanceError: this.balanceError ? this.balanceError : null,
     }
   }
 
@@ -111,10 +121,16 @@ class Token {
     let result
     try {
       result = await this.contract[methodName](...args)
+      if (key === 'balance') {
+        this.balanceError === null
+      }
     } catch (e) {
       console.warn(`failed to load ${key} for token at ${this.address}`)
       if (key === 'balance') {
-        throw e
+        this.balanceError = e
+        if (this.throwOnBalanceError) {
+          throw e
+        }
       }
     }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -55,6 +55,7 @@ test('tracker with token added after initialization', async function (t) {
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
       ],
       'should have expected initial state'
@@ -98,6 +99,7 @@ test('tracker with minimal token', async function (t) {
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
       ],
       'should have expected initial state'
@@ -143,6 +145,7 @@ test('tracker with token including metadata', async function (t) {
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
       ],
       'should have expected initial state'
@@ -188,6 +191,7 @@ test('tracker with minimal token and one block update with no changes', async fu
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
       ],
       'should have expected initial state'
@@ -236,6 +240,7 @@ test('tracker with minimal token and two rapid block updates, the first with cha
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
         [{
           address: tokenAddress,
@@ -243,6 +248,7 @@ test('tracker with minimal token and two rapid block updates, the first with cha
           balance: '110',
           decimals: 0,
           string: '110',
+          balanceError: null,
         }],
       ],
       'should have expected state for both updates'
@@ -286,6 +292,7 @@ test('tracker with minimal token and one block update with changes', async funct
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
         [{
           address: tokenAddress,
@@ -293,6 +300,7 @@ test('tracker with minimal token and one block update with changes', async funct
           balance: '110',
           decimals: 0,
           string: '110',
+          balanceError: null,
         }],
       ],
       'should have expected state for both updates'
@@ -335,6 +343,7 @@ test('tracker with minimal token and one immediate block update with changes', a
           balance: '0',
           decimals: 0,
           string: '0',
+          balanceError: null,
         }],
         [{
           address: tokenAddress,
@@ -342,6 +351,7 @@ test('tracker with minimal token and one immediate block update with changes', a
           balance: '110',
           decimals: 0,
           string: '110',
+          balanceError: null,
         }],
       ],
       'should have expected state for both updates'
@@ -368,6 +378,31 @@ test('tracker with broken provider', async function (t) {
     })
     tracker.on('error', () => {
       t.pass('should emit error event')
+    })
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+    t.end()
+  } finally {
+    tracker.stop()
+  }
+})
+
+test('tracker with broken provider and includeFailedTokens', async function (t) {
+  t.plan(1)
+  let tracker
+  try {
+    tracker = new TokenTracker({
+      provider: {
+        sendAsync: () => {
+          throw new Error('Fake provider error')
+        }
+      },
+      includeFailedTokens: true,
+      tokens: [{
+        address: '0xf83c3761a5c0042ab9a694d29520aa9cd6788987',
+      }],
+    })
+    tracker.on('update', () => {
+      t.pass('should emit update event')
     })
     await new Promise((resolve) => setTimeout(() => resolve(), 200))
     t.end()

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -44,7 +44,8 @@ test('token with minimal options', async function (t) {
       symbol: undefined,
       balance: '0',
       decimals: 0,
-      string: '0'
+      string: '0',
+      balanceError: null,
     },
     'should serialize minimal token correctly',
   )


### PR DESCRIPTION
1. adds a new option flag (`includeFailedToken`)
2. passes that flag to the Token constructor as `throwOnBalanceError`
3. if `throwOnBalanceError` is false, do not throw an error when balance update fails
4. always attach `balanceError` to the token when an error occurs, and clear it when update succeeds

This allows us to display failed tokens in the extension AND only show our tooltip warning about token balances on the tokens that did not successfully update. Put this behind a flag to allow the prior behavior to work by default