### PR TITLE
add support for isERC721 flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ class TokenTracker extends SafeEventEmitter {
 
   createTokenFrom (opts) {
     const owner = this.userAddress
-    const { address, symbol, balance, decimals } = opts
+    const { address, symbol, balance, decimals, isERC721 } = opts
     const contract = this.TokenContract.at(address)
     return new Token({
       address,
@@ -76,6 +76,7 @@ class TokenTracker extends SafeEventEmitter {
       decimals,
       contract,
       owner,
+      isERC721,
       throwOnBalanceError: this.includeFailedTokens === false,
     })
   }

--- a/lib/token.js
+++ b/lib/token.js
@@ -31,6 +31,7 @@ class Token {
     decimals,
     contract,
     owner,
+    isERC721,
     throwOnBalanceError
   } = {}) {
     if (!contract) {
@@ -42,6 +43,7 @@ class Token {
     this.address = address || '0x0'
     this.symbol  = symbol
     this.throwOnBalanceError = throwOnBalanceError
+    this.isERC721 = isERC721
 
     if (!balance) {
       balance = '0'
@@ -77,6 +79,7 @@ class Token {
       decimals: this.decimals ? parseInt(this.decimals.toString()) : 0,
       string: this.stringify(),
       balanceError: this.balanceError ? this.balanceError : null,
+      isERC721: this.isERC721,
     }
   }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -56,6 +56,7 @@ test('tracker with token added after initialization', async function (t) {
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected initial state'
@@ -100,6 +101,7 @@ test('tracker with minimal token', async function (t) {
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected initial state'
@@ -146,6 +148,7 @@ test('tracker with token including metadata', async function (t) {
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected initial state'
@@ -192,6 +195,7 @@ test('tracker with minimal token and one block update with no changes', async fu
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected initial state'
@@ -241,6 +245,7 @@ test('tracker with minimal token and two rapid block updates, the first with cha
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
         [{
           address: tokenAddress,
@@ -249,6 +254,7 @@ test('tracker with minimal token and two rapid block updates, the first with cha
           decimals: 0,
           string: '110',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected state for both updates'
@@ -293,6 +299,7 @@ test('tracker with minimal token and one block update with changes', async funct
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
         [{
           address: tokenAddress,
@@ -301,6 +308,7 @@ test('tracker with minimal token and one block update with changes', async funct
           decimals: 0,
           string: '110',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected state for both updates'
@@ -344,6 +352,7 @@ test('tracker with minimal token and one immediate block update with changes', a
           decimals: 0,
           string: '0',
           balanceError: null,
+          isERC721: undefined,
         }],
         [{
           address: tokenAddress,
@@ -352,6 +361,7 @@ test('tracker with minimal token and one immediate block update with changes', a
           decimals: 0,
           string: '110',
           balanceError: null,
+          isERC721: undefined,
         }],
       ],
       'should have expected state for both updates'

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -46,6 +46,7 @@ test('token with minimal options', async function (t) {
       decimals: 0,
       string: '0',
       balanceError: null,
+      isERC721: undefined,
     },
     'should serialize minimal token correctly',
   )


### PR DESCRIPTION
A new field - isERC721 -[ is being added to tokens within the MetaMask extension repo]((https://github.com/MetaMask/metamask-extension/pull/11210)). Adding the field to the tracker is narrowly helpful for improving the way this field can be used within the extension. 