### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [4.0.0] - 2021-11-18
+- Sets the minimum Node.js version to v12 (#58)
 - Support configuration of the number of decimals in the balance returned by `stringify`, via a new `balanceDecimals`
 property on the config object passed to the Token constructor (#71)
+- Properly clear error state after retrieving a balance successfully (#73)
 
 ## [3.1.0] - 2020-11-17
 - Add ability to include tokens with balance errors in update events, behind an option flag (#53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2021-11-18
+- Support configuration of the number of decimals in the balance returned by `stringify`, via a new `balanceDecimals`
+property on the config object passed to the Token constructor (#71)
+
 ## [3.1.0] - 2020-11-17
 - Add ability to include tokens with balance errors in update events, behind an option flag (#53)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0] - 2021-11-18
+## [4.0.0] - 2022-01-05
 - Sets the minimum Node.js version to v12 (#58)
 - Support configuration of the number of decimals in the balance returned by `stringify`, via a new `balanceDecimals`
 property on the config object passed to the Token constructor (#71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0] - 2022-01-05
+## [4.0.0] - 2022-01-10
 - Set the minimum Node.js version to v12 (#58)
 - Support configuration of the number of decimals in the balance returned by `stringify`, via a new `balanceDecimals`
 property on the config object passed to the Token constructor (#71)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [4.0.0] - 2022-01-05
-- Sets the minimum Node.js version to v12 (#58)
+- Set the minimum Node.js version to v12 (#58)
 - Support configuration of the number of decimals in the balance returned by `stringify`, via a new `balanceDecimals`
 property on the config object passed to the Token constructor (#71)
 - Properly clear error state after retrieving a balance successfully (#73)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-token-tracker",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A module for tracking Ethereum token balances over block changes.",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Bumps the version in package.json and updates the changelog

Replaces https://github.com/MetaMask/eth-token-tracker/pull/72, because as @Gudahtt recognized in [this comment](https://github.com/MetaMask/eth-token-tracker/pull/72#issuecomment-989924855), this version includes the breaking change of updating the minimum node version