### PR TITLE
devDeps: bump solc@0.4.25->0.4.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "ethereumjs-testrpc": "^3.0.4",
-    "solc": "^0.4.10",
+    "solc": "^0.4.26",
     "tape": "^4.6.3",
     "web3-provider-engine": "^15.0.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-solc@^0.4.10:
-  version "0.4.25"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.25.tgz#06b8321f7112d95b4b903639b1138a4d292f5faa"
-  integrity sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==
+solc@^0.4.26:
+  version "0.4.26"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.26.tgz#5390a62a99f40806b86258c737c1cf653cc35cb5"
+  integrity sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
This resolves solc throwing an unhandled exception on nodejs versions >12

https://github.com/legobeat/eth-token-tracker/actions/runs/3645421931/jobs/6155557837#step:5:16