### PR TITLE
Release v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.0.0] - 2023-08-04
 - **BREAKING**: Set the minimum Node.js version to v16 (#105)
 - Update dependency eth-block-tracker@^6.1.0->^7.1.0 (#105)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-token-tracker",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A module for tracking Ethereum token balances over block changes.",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
Changes since v5.0.0:

- **BREAKING**: Set the minimum Node.js version to v16 (#105)
- Update dependency eth-block-tracker@^6.1.0->^7.1.0 (#105)