### PR TITLE
fix: add @babel/runtime to peerDeps and devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,12 @@
     "@babel/core": "^7.5.5",
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
+    "@babel/runtime": "^7.21.0",
     "ganache": "7.3.1",
     "solc": "^0.4.26",
     "tape": "^5.6.1"
+  },
+  "peerDependencies": {
+    "@babel/runtime": "^7.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,7 +898,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.8.4":
+"@babel/runtime@^7.21.0", "@babel/runtime@^7.8.4":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==


### PR DESCRIPTION
This package has an undeclared peerDependency on `@babel/runtime`.  When trying to `require('@metamask/eth-method-registry')` as a module from an otherwise empty test project we get the following error (and can see the corresponding usage at top of the bundled entrypoint):

```
$ node index.js
node:internal/modules/cjs/loader:1031
  throw err;
  ^

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
Require stack:
- node_modules/@metamask/eth-token-tracker/dist/index.js
- index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1028:15)
    at Function.Module._load (node:internal/modules/cjs/loader:873:27)
    at Module.require (node:internal/modules/cjs/loader:1100:19)
    at require (node:internal/modules/cjs/helpers:119:18)
    at Object.<anonymous> (node_modules/@metamask/eth-token-tracker/dist/index.js:3:30)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
    at Module.require (node:internal/modules/cjs/loader:1100:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'node_modules/@metamask/eth-token-tracker/dist/index.js',
    'index.js'
  ]
}
```

This is the case for version `4.0.1` through `7.0.1`. In `4.0.0` and lower, we don't see the error because `@babel/runtime@^7.5.5` got pulled in separately as a transitive runtime dependency from older versions of `eth-block-tracker`, which removed it as of v5.0.0. (#86)

I picked `^7.21.0`, since `@babel/runtime@7.21.0` is what's already present in the lockfile of this package and used in tests as of #95 (see as for why not lower).

#### Fixed
- Add missing peerDependency `@babel/runtime`
