### PR TITLE
fix ci by updating node 22x version to 22.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A module for tracking Ethereum token balances over block changes.",
   "main": "dist/index.js",
   "engines": {
-    "node": "^18.16.1 || ^20 || >=22"
+    "node": "^18.16.1 || ^20 || >=22.5.1"
   },
   "scripts": {
     "lint": "yarn lint:dependencies",


### PR DESCRIPTION
There seems to be a regression in Node 22.5.0 which https://github.com/yarnpkg/berry/issues/6398 and in turns prevents CI from completing successfully. This regression was https://github.com/nodejs/node/pull/53935. We are using 22.x in CI, so in theory it should be using this version, but that does not seem be the case right now. So this commit ensures that CI is using this version by naming it explicitly.